### PR TITLE
removed scheduled word wrt Ruby 1.8.7 upgrade. Also removed the horizonta

### DIFF
--- a/pages/appcloud_updates_july_2011.md
+++ b/pages/appcloud_updates_july_2011.md
@@ -3,19 +3,15 @@
 The updates described are either important (where you need to take action) or of interest (you might want to know about these changes but you don't need to do anything). 
 
 
----
-
 <a href=#update4><h2 id="update4"> **Action Req'd:** Upgrade to Ruby 1.8.7-p352 </h2></a>
 
-July 22nd, 2011 (scheduled)
+July 22nd, 2011
 
 AppCloud will be upgraded to Ruby 1.8.7-p352 on or around July 22nd. 
 
 If you are using Ruby 1.8.7 and Unicorn, you must redeploy after updating.
 
 If you are using Ruby 1.8.7 and Passenger, we recommend that you redeploy after updating. This is to make sure that your code runs under the latest version of the MRI interpreter.
-
----
 
 <a href=#update6><h2 id="update6"> **Major:** Improvements to the app-centric UI: more details and easier deploys </h2></a>
 
@@ -28,8 +24,6 @@ In response to user feedback, we made some modifications to our application-cent
 *  More detailed instance lists
 *  Flags to clearly indicate whether an environment is production, staging, or development 
 
----
-
 <a href=#update5><h2 id="update5"> **Major:** JRuby is now available in Beta for all customers </h2></a>
 
 July 18th, 2011
@@ -41,23 +35,17 @@ Run production-quality Ruby on Rails applications on AppCloud via [[JRuby|http:/
 For more information, see [[Getting Started with JRuby|jruby-beta]] and [[JRuby on AppCloud available through Beta program|http://www.engineyard.com/blog/2011/jruby-on-appcloud-available-through-beta-program/]].
 
 
----
-
 <a href=#update3><h2 id="update3"> Minor: Increased maximum connections for HAProxy </h2></a>
 
 July 8th, 2011
 
 The maximum number of connections for HAProxy increased to 65,535 from 15,000.
 
----
-
 <a href=#update2><h2 id="update2"> Minor: Upgrade to Redis 2.2.11</h2></a>
 
 July 8th, 2011
 
 For more information, see the [[Redis 2.2 release notes|https://github.com/antirez/redis/blob/2.2.11/00-RELEASENOTES]].
-
----
 
 <a href=#update1> <h2 id="update1"> Minor: Nginx Upload Progress module upgraded </h2></a>
 

--- a/pages/appcloud_updates_june_2011.md
+++ b/pages/appcloud_updates_june_2011.md
@@ -2,8 +2,6 @@
 
 The updates described are either important (where you need to take action) or of interest (you might want to know about these changes but you don't need to do anything). 
 
----
-
 <a href=#update16><h2 id="update16"> **Major:** Passenger 3 is now available with Beta support</h2></a>
 
 June 29th, 2011
@@ -11,8 +9,6 @@ June 29th, 2011
 Phusion Passenger 3 is available with Beta support in AppCloud. (No sign-up required.)
 
 Passenger 3 brings substantial performance improvements over Passenger 2. For more information, see [[Using Passenger 3 with Engine Yard AppCloud|using-passenger-with-engine-yard-appcloud]].
-
----
 
 <a href=#update15><h2 id="update15"> Minor: The new Basic Cluster environment is now three medium servers </h2></a>
 
@@ -25,15 +21,11 @@ For new environments, the default configuration is now a Basic Cluster of:
 
 Previously, the default environment was the Single Server configuration, and the Basic Cluster had only one application server (and one database server).
 
----
-
 <a href=#update14><h2 id="update14"> Fix: Changing the domain name for an environment </h2></a>
 
 June 28th, 2011
 
 Fixed an issue where changes to the Domain Name field were not saved. Domain names can now be changed in the Edit the Environment page.
-
----
 
 <a href=#update13><h2 id="update13"> Minor: A link to a sample application in GitHub is provided on the New Application page </h2></a>
 
@@ -44,8 +36,6 @@ If you are new to AppCloud, test our sample repository and get the ToDo applicat
 Click Try our sample… to populate the Git Repository URI with the source code for the ToDo application.
 
 ![Try our sample ToDo application](images/github_sample_repo.png)
-
----
 
 <a href=#update12><h2 id="update12"> Minor: Improved alert for out-of-date stacks </h2></a>
 
@@ -58,23 +48,17 @@ When your Engine Yard stack is not the most current, you see this message under 
 Click !Update to update the stack. The message persists until the instance is running again and you refresh the browser page. 
 
 
----
-
 <a href=#update11><h2 id="update11"> Minor: The dashboard is now application-centric </h2></a>
 
 June 21st, 2011
 
 The dashboard has moved from an *environment*-centric user interface to an *application*-centric user interface. For more information about this change, see [[We’re Getting Application-centric!|http://www.engineyard.com/blog/2011/were-getting-application-centric/]]
 
----
-
 <a href=#update10><h2 id="update10"> Minor: The default DB volume size is now 15GB </h2></a>
 
 June 16th, 2011
 
 The default size of the database volume has increased from 5GB to 15GB.
-
----
 
 <a href=#update9><h2 id="update9"> Minor: Mongrel is deprecated for new environments  </h2></a>
 
@@ -84,15 +68,11 @@ This does not affect environments currently running Mongrel.
 
 If you need to create a new environment where Mongrel is the application server stack, please file a ticket with [[Engine Yard Support|http://support.cloud.engineyard.com]].
 
----
-
 <a href=#update8><h2 id="update8"> Fix: Automatic snapshot size </h2></a>
 
 June 8th, 2011
 
 Fixed an issue where the snapshot-size text field was not automatically updated when a specific snapshot was selected.
-
----
 
 <a href=#update7><h2 id="update7"> Fix: Environment update notification </h2></a>
 
@@ -100,15 +80,11 @@ June 8th, 2011
 
 Fixed an issue where some environments were not marked as needing an update.
 
----
-
 <a href=#update6><h2 id="update6"> Fix: Rubygems 1.5.2 </h2></a>
 
 June 3rd, 2011
 
 Patched a bug fix from June 1st that was causing problems.
-
----
 
 <a href=#update5><h2 id="update5"> **Major:** High memory XL VM’s available </h2></a>
 
@@ -124,8 +100,6 @@ You can now create high memory extra-large VM’s in your environment:
 
 See [[www.engineyard.com/products/appcloud/pricing|http://www.engineyard.com/products/appcloud/pricing]] for pricing.
 
----
-
 <a href=#update4><h2 id="update4"> Minor: Environment variables for custom scripts </h2></a>
 
 June 2nd, 2011
@@ -134,16 +108,11 @@ If you use custom scripts, your applications now have access to specific stack e
 
 You can source /engineyard/bin/env.sh to access these variables: $EY_ENVIRONMENT_NAME, $EY_STACK, $EY_FRAMEWORK_ENV, $RAILS_ENV, $RACK_ENV, and $MERB_ENV.
 
-
----
-
 <a href=#update3><h2 id="update3"> Fix: HAproxy restart from single instance snapshot </h2></a>
 
 June 2nd, 2011
 
 Fixed an issue where HAproxy was failing to restart when creating a cluster from a single instance snapshot.
-
----
 
 <a href=#update2><h2 id="update2"> Fix: Rubygems 1.5.2 update</h2></a>
 
@@ -151,8 +120,6 @@ June 2nd, 2011
 
 Upgrading to rubygems 1.5.2 was breaking Rails applications. This issue was fixed by adding version_requirements back into rubygems 1.5.2.
 
-
----
 
 <a href=#update1> <h2 id="update1"> **Major:** X-Forwarded-For SSL traffic enabled </h2></a>
 


### PR DESCRIPTION
removed scheduled word wrt Ruby 1.8.7 upgrade. Also removed the horizontal lines from june and july release notes
