### PR TITLE
Windows SSH Keys

### DIFF
--- a/pages/windows-ssh-keys.md
+++ b/pages/windows-ssh-keys.md
@@ -1,18 +1,23 @@
-# How to add SSH keys to AppCloud from Windows
+# Adding SSH keys to AppCloud from Windows
 
 On Windows there are a number of ways to create an SSH key pair including
 RailsInstaller, PuTTY, and Cygwin. Engine Yard supports the RailsInstaller
 method since it is the most straight-forward method. Using another method
-is out of the scope of this document
+is out of the scope of this document.
 
-## Creating keys
+This is a two step process:
+
+* [[Create keys|windows-ssh-keys#create]]
+* [[Add keys to AppCloud|windows-ssh-keys#add]]
+
+<h2 id="create"> To create keys</h2>
 
 RailsInstaller automatically creates SSH keys in `~/.ssh`
-(`C:\Users\<user_name>\.ssh`). If you need to re-create them, this is the
-supported way. This document also used Unix-style commands and paths because
-that is what git-bash uses.
+`C:\Users\<user_name>\.ssh`. If you need to re-create them, follow the steps below. This procedure uses unix-style commands and paths because that is what git-bash uses.
 
-1. Using git-bash (Start -> Programs -> RailsInstaller -> git-bash), change directories into your home folder
+1. Navigate to Start -> Programs -> RailsInstaller -> git-bash.
+
+1. Change directories into your home folder
 
         cd ~
 
@@ -25,29 +30,25 @@ reject it)
 
         chmod -R 644 ~/.ssh
 
-You should now have a private and public key, `~/.ssh/id_rsa` and `~/.ssh/id_rsa.pub`, respectively
+You should now have a private and public key, `~/.ssh/id_rsa` and `~/.ssh/id_rsa.pub`, respectively.
 
-## Add keys to AppCloud
+<h2 id="add"> To add keys to AppCloud </h2>
 
-1. From the AppCloud Dashboard, click 'SSH Public Keys'
+1. In your AppCloud Dashboard, click SSH Public Keys.
 
-2. Click the 'Add new SSH public key' button
+2. Click Add new SSH public key.
 
-3. Fill in the 'Name' field with whatever you want to identify the key
+3. Enter a name in the Name field to identify the key.
 
-4. Open the public key (`~/.ssh/id_rsa.pub`) in Notepad
+4. Open the public key (`~/.ssh/id_rsa.pub`) in Notepad.
 
-        notedpad ~/.ssh/id_rsa.pub
+        notepad ~/.ssh/id_rsa.pub
         
-5. Copy everything
+5. Copy the key to the clipboard.
 
-        Ctrl-a Ctrl-c
+6. Paste into the Public Key field.
 
-6. Paste into the 'Public Key' field
+7. Make sure to select the environments that you want to add this key to. If you don't
+have any environments, this key is automatically added to the ones you create.
 
-        Ctrl-v
-
-7. Make sure and select which environments to add this key to. If you don't
-have any environments it will automatically be added to the ones you create.
-
-8. Click the 'Add Key' button and everything should be setup in AppCloud
+8. Click Add Key and your new key is setup in AppCloud.

--- a/pages/windows-ssh-keys.md
+++ b/pages/windows-ssh-keys.md
@@ -1,0 +1,53 @@
+# How to add SSH keys to AppCloud from Windows
+
+On Windows there are a number of ways to create an SSH key pair including
+RailsInstaller, PuTTY, and Cygwin. Engine Yard supports the RailsInstaller
+method since it is the most straight-forward method. Using another method
+is out of the scope of this document
+
+## Creating keys
+
+RailsInstaller automatically creates SSH keys in `~/.ssh`
+(`C:\Users\<user_name>\.ssh`). If you need to re-create them, this is the
+supported way. This document also used Unix-style commands and paths because
+that is what git-bash uses.
+
+1. Using git-bash (Start -> Programs -> RailsInstaller -> git-bash), change directories into your home folder
+
+        cd ~
+
+2. Generate the SSH keys (make sure to use a strong password or AppCloud will
+reject it)
+
+        ssh-keygen -t rsa
+
+3. Change the permissions of the SSH folder and keys
+
+        chmod -R 644 ~/.ssh
+
+You should now have a private and public key, `~/.ssh/id_rsa` and `~/.ssh/id_rsa.pub`, respectively
+
+## Add keys to AppCloud
+
+1. From the AppCloud Dashboard, click 'SSH Public Keys'
+
+2. Click the 'Add new SSH public key' button
+
+3. Fill in the 'Name' field with whatever you want to identify the key
+
+4. Open the public key (`~/.ssh/id_rsa.pub`) in Notepad
+
+        notedpad ~/.ssh/id_rsa.pub
+        
+5. Copy everything
+
+        Ctrl-a Ctrl-c
+
+6. Paste into the 'Public Key' field
+
+        Ctrl-v
+
+7. Make sure and select which environments to add this key to. If you don't
+have any environments it will automatically be added to the ones you create.
+
+8. Click the 'Add Key' button and everything should be setup in AppCloud


### PR DESCRIPTION
Documenting creating SSH keys and adding them to AppCloud from Windows. Uses RailsInstaller as the supported method.
