### PR TITLE
DOC-100 this commit contains the environment-upgrade page but no links to

### DIFF
--- a/pages/app-troubleshooting.md
+++ b/pages/app-troubleshooting.md
@@ -5,5 +5,5 @@
 * ### [[Amazon: Out of Capacity Error|amazon-out-of-capacity]]
   Learn more about this Amazon error when booting new instances on AppCloud.
 
-* ### [[Termination failed|trouble-termination-failed]]
+* ### [[Termination Failed error when shutting down an instance|trouble-termination-failed]]
   Learn more about what to do if an instance does not terminate.

--- a/pages/environment-upgrade.md
+++ b/pages/environment-upgrade.md
@@ -1,0 +1,60 @@
+<h1>Upgrading an environment</h1>
+
+From time to time, Engine Yard releases a new stack version. When a new stack is released, you have the option to upgrade your environment and take advantage of the latest features and fixes. Some reasons Engine Yard releases a new stack are:  
+
+* Upgrading a stack component to a newer version 
+* Addressing vulnerabilities
+* Bug fixes     
+
+When Engine Yard releases a new stack, an **! Upgrade...** button appears on the environment.
+
+![upgrades available](images/upgrades_available.png) 
+
+Before you upgrade, you can review the changes that will be applied to your current environment.
+
+<h3>Process</h3>
+
+This is the process for upgrading a production environment:  
+
+* [Test the upgraded environment on a clone.][3]  
+* [Upgrade the production environment.][2]
+
+<h3> Cloned environments vs. new environments</h3> 
+
+When you clone an environment, the cloned stack is the same version as the original stack. However, if you create a new environment, it is always the latest stack version. 
+
+<h3>About adding instances to an existing environment</h3>
+
+When you add a new instance to an existing environment, the added instance is the same stack version as the other instances in that environment. You do not have to upgrade before adding an instance.
+
+
+<h2 id="test">Test an upgrade</h2>
+
+Best practice is to test in a non-production environment before upgrading a production environment. Don't upgrade your production environment until you have validated the upgrade in a test environment. 
+
+
+<h3>To test an upgrade</h3>
+1. Clone the environment. (See [[Clone an environment on AppCloud|environment-clone]].)  
+2. Upgrade the cloned environment, following the procedure [below][4].
+3. Test the application on the cloned environment.
+4. Upgrade the production environment, following the procedure [below][4].
+5. Decommission the cloned environment. (See [[Delete an environment on AppCloud|environment-delete]].)
+
+
+<h2 id="topic2">Upgrade an environment</h2>
+
+When a new stack is available, you see a "Please Upgrade" message on your AppCloud dashboard and the ! Upgrade button on the environment pages.
+
+<b>Important!</b> If your stack is very out-of-date, you see this message: "Upgrading will enable Stack Change Management." Remember, when updating a very out-of-date stack for a production environment, always test in a cloned environment first. 
+
+<h3 id="upgrade">To upgrade an environment</h3>
+1. In your AppCloud dashboard, click the environment name.    
+2. Click ! Upgrade...  
+    The Upgrades Available page appears.  
+3. Review the Changes list.  
+3. Click Upgrade Environment.
+
+[1]: #topic1        "topic1"
+[2]: #topic2        "topic2"
+[3]: #test        "test"
+[4]: #upgrade        "upgrade"

--- a/pages/trouble-termination-failed.md
+++ b/pages/trouble-termination-failed.md
@@ -1,17 +1,17 @@
-<h1>Termination failed</h1>
+<h1>Termination Failed error when shutting down an instance</h1>
 
-<b>Symptom</b>  
+Occasionally, Amazon cannot shut down an instance when a termination request is made. If this happens, you get a "Termination Failed" message. 
 
 The Instances tab shows "Termination Failed" for one or more instances.  
 
 ![termination failed message](images/termination_failed.png)
 
-<b>Solution</b>
+<h2> To resolve a Termination Failed error </h2>
 
-Occasionally, Amazon cannot shut down an instance when a termination request is made. If this happens, you get a "Termination Failed" message. You can do one of two things:  
+1. Do one of the following:  
 
-*  Click <b>Retry</b> to try again to terminate the instance. If AppCloud cannot terminate the instance within 10 minutes, it returns another "Termination Failed" message.
+    *  Click <b>Retry</b> to try again to terminate the instance. If AppCloud cannot terminate the instance within 10 minutes, it returns another "Termination Failed" message.
 
-*  Click <b>Force</b> to force-terminate the instance. 
+    *  Click <b>Force</b> to force-terminate the instance. 
 
-<b>Important!</b> If you select Force, the termination snapshot might not be good. If you later boot a cluster and use a "force-terminated" snapshot for the application instance, make sure to test the instance.
+        <b>Important!</b> If you select Force, the termination snapshot might not be good. If you later boot a cluster and use a "force-terminated" snapshot for the application instance, make sure to test the instance.


### PR DESCRIPTION
DOC-100 this commit contains the environment-upgrade page but no links to it. Plus my rewrite in the new style for the Termination Failed troubleshooting page.
