### PR TITLE
DOC-125 correcting the tech stack page that showed resque still in Alpha 

### DIFF
--- a/pages/appcloud-tech-stack.md
+++ b/pages/appcloud-tech-stack.md
@@ -655,13 +655,13 @@ As a result, you can confidently deploy and manage your application with any Eng
       <td></td>
       <td>
         <ul>
-          <li class="experimental" title='Experimental'>1.5.0
+          <li class="full" title='Full'>1.5.0
           </li>
         </ul>
       </td>
       <td>
         <ul>
-          <li class="experimental" title='Experimental'>1.5.0 
+          <li class="full" title='Full'>1.5.0 
           </li>
         </ul>
       </td>


### PR DESCRIPTION
DOC-125 correcting the tech stack page that showed resque still in Alpha . Page edited is appcloud-tech-stack.html
