### PR TITLE
DOC-169 release notes for SQL stored procedures not needing Super privile

### DIFF
--- a/pages/appcloud_updates_june_2011.md
+++ b/pages/appcloud_updates_june_2011.md
@@ -10,7 +10,7 @@ June 29th, 2011
 
 Phusion Passenger 3 is available with Beta support in AppCloud. (No sign-up required.)
 
-Passenger 3 brings substantial performance improvements over Passenger 2. For more information, see [[Using Passenger 3 with Engine Yard AppCloud|using-passenger-with-engine-yard-appcloud]].
+Passenger 3 brings substantial performance improvements over Passenger 2.
 
 
 

--- a/pages/appcloud_updates_september_2011.md
+++ b/pages/appcloud_updates_september_2011.md
@@ -3,12 +3,12 @@
 The updates described are either important (where you need to take action) or of interest (you might want to know about these changes but you don't need to do anything). 
 
 
-<a href=#update3><h2 id="update3"> Fix: Multiple accounts during trial signup</h2></a>
+<a href=#update3><h2 id="update3"> Minor: The Deploy user can create and load SQL stored procedures</h2></a>
 
-September 2nd, 2011
+September 7th, 2011
 
-Fixed an issue where clicking reload or submit could accidentally create multiple accounts when signing up for a single trial account.
-  
+Added log-bin-trust-function-creators to allow deploy users to create and upload SQL stored procedures. After this upgrade, you no longer have to add the Super privilege for the deploy user to create and load SQL stored procedures.
+    
 
 <a href=#update2><h2 id="update2"> Minor: NTP is multi-region aware</h2></a>
 

--- a/pages/release_notes.md
+++ b/pages/release_notes.md
@@ -3,7 +3,7 @@
 
 ### [[September 2011|appcloud_updates_september_2011]]
 
-* [[Fix: Multiple accounts during trial signup|appcloud_updates_september_2011#update3]] *September 2nd, 2011*
+* [[Minor: The Deploy user can create and load SQL stored procedures|appcloud_updates_september_2011#update3]] *September 7th, 2011*
 
 * [[Minor: NTP is multi-region aware|appcloud_updates_september_2011#update2]] *September 1st, 2011*
 


### PR DESCRIPTION
DOC-169 release notes for SQL stored procedures not needing Super privileges and removed the note about multiple users cause it is still broke. Fixed a dud link in June too.
