### PR TITLE
Update asset pipeline

### DIFF
--- a/pages/asset-pipeline.md
+++ b/pages/asset-pipeline.md
@@ -9,6 +9,8 @@ Topics covered on this page:
 
 <h2 id="precompile">Precompiling assets</h2>
 
+**NOTE: Only try this fix if styles are not displayed correctly**
+
 When deploying your Rails 3.1 application, you may notice that there is no
 styling or your javascript behavior is not working. The fix for this is requires adding a [[deploy hook|use-deploy-hooks-with-engine-yard-appcloud]] to your application.
 

--- a/pages/deployment-windows.md
+++ b/pages/deployment-windows.md
@@ -25,12 +25,25 @@ Steps to create and deploy your application from Windows:
 
 1. Open the `Gemfile.lock` file in your application.
 2. Under Platforms, add `ruby` if it doesn't exist.
-2. If there are any gems with `x86-minw32`, make sure to explicitly add them to the Gemfile (`gem 'bcrypt-ruby'`).
+2. If there are any gems with `-x86-minwg32`, make sure to remove the
+  `-x86-mingw32` and add specify it explicitly in the Gemfile with the
+  platform.
+        
+      bcrypt-ruby (3.0.1-x86-mingw32)
+
+  becomes
+
+      bcrypt-ruby (3.0.1)
+      
+  in Gemfile
+  
+      gem 'bcrypt-ruby', '~> 3.0.1', :platform => 'ruby'
+        
 3. Specify the bundler version in the Gemfile 
 
         gem 'bundler', '~> 1.0.17'
     
-3. Bundle the application again from the command prompt
+4. Bundle the application again from the command prompt
     
         bundle install
     


### PR DESCRIPTION
- Add note to asset pipeline to only worry about precompiling assets if styles are not showing.
- More issues for Windows deployment.
