### PR TITLE
DOC-280 release notes for postgres and mysql fixes and for adding ZSH whi

### DIFF
--- a/pages/Home.md
+++ b/pages/Home.md
@@ -19,18 +19,18 @@ Engine Yard is a Ruby on Rails Platform as a Service that provides the ability t
   <div class="col col-first">
     <h2>Updated documentation</h2>
     <ul>
-      	<li>
+	   <li>
+	      [[Engine Yard Cloud updates October 2011|appcloud-updates-october-2011]]
+	   </li>
+      <li>
+	      [[Site is down: Diagnostic checklist|site-is-down]]
+	  </li>
+	  <li>
         [[Clone an environment|environment-clone]]
       </li>
-      <li>
-      [[Engine Yard Cloud updates October 2011|appcloud-updates-october-2011]]
-      </li>
+      
       <li>
         [[Using Rubinius with Engine Yard Cloud|using-rubinius-on-appcloud]]
-      </li>
-	  
-      <li>
-        [[Customize Unicorn|customize-unicorn]]
       </li>
     </ul>
 

--- a/pages/appcloud-updates-october-2011.md
+++ b/pages/appcloud-updates-october-2011.md
@@ -2,6 +2,20 @@
 
 The updates described are either important (where you need to take action) or of interest (you might want to know about these changes but you don't need to do anything). 
 
+<a href=#update13><h2 id="update13">Fix: Two database-related issues</h2></a>
+
+October 26th, 2011
+
+* Fixed an issue with PostgreSQL 9.0 Alpha backups. (In some cases, database slaves were not getting backed up.)
+
+* Fixed an issue where a MySQL slave server could not be added to a cluster if the master database had master.info or relay-log.info files on it.
+
+<a href=#update12><h2 id="update12">Fix: ZSH installation</h2></a>
+
+October 26th, 2011
+
+ZSH is now installed.
+
 <a href=#update11><h2 id="update11">Minor: Assorted improvements and fixes to the Engine Yard Stack</h2></a>
 
 October 22nd, 2011

--- a/pages/configure-and-deploy-resque.md
+++ b/pages/configure-and-deploy-resque.md
@@ -38,7 +38,7 @@ If you want to get going and work the rest out later, here's the quick version.
 3. Add `config/resque.yml` as per the Resque readme
     - Typically this is in `/data/app_name/shared/config/resque.yml` and you use a deploy hook to symlink this into `current/config`.
 4. For each worker you want to have, create a `resque_x.conf`
-    - (where x is a number for the worker counting from 0) IF you want to use this mechanism to prioritize. Otherwise, you can skip this step.
+    - (where x is a number for the worker counting from 0) If you want to use this mechanism to prioritize. Otherwise, you can skip this step.
 5. Enable the Resque recipe in chef (read `/etc/chef-custom/recipes/cookbooks/resque/README.rdoc`), and upload your recipes.
 6. Add deploy hooks to your code to ensure that the workers are restarted during deploys.
 

--- a/pages/release_notes.md
+++ b/pages/release_notes.md
@@ -3,6 +3,10 @@
 
 ### [[October 2011|appcloud-updates-october-2011]]
 
+* [[Fix: Database-related issues|appcloud-updates-october-2011#update13]] *October 26th, 2011*
+
+* [[Fix: ZSH installation|appcloud-updates-october-2011#update12]] *October 26th, 2011*
+
 * [[Minor: Assorted improvements and fixes to the Engine Yard Stack|appcloud-updates-october-2011#update11]] *October 22nd, 2011*
 
 * [[Minor: No more tabs on the Environment page|appcloud-updates-october-2011#update10]] *October 18th, 2011*


### PR DESCRIPTION
DOC-280 release notes for postgres and mysql fixes and for adding ZSH which had never been installed and updating the home page with the latest updated docs and correcting IF to If on the configure and deploy resque page.
