### PR TITLE
removing June 2nd release note about Major: X-Forwarded-For SSL traffic e

### DIFF
--- a/pages/appcloud_updates_june_2011.md
+++ b/pages/appcloud_updates_june_2011.md
@@ -154,12 +154,6 @@ Upgrading to rubygems 1.5.2 was breaking Rails applications. This issue was fixe
 
 
 
-<a href=#update1> <h2 id="update1"> **Major:** X-Forwarded-For SSL traffic enabled </h2></a>
-
-June 2nd, 2011
-
-You can now request Engine Yard Support to enable HTTPS support of X-Forwarded-For via stunneled feature.
-
 
 
 [1]: #update1        "update1"

--- a/pages/release_notes.md
+++ b/pages/release_notes.md
@@ -158,10 +158,7 @@
 
 * [[Fix: HAproxy restart from single instance snapshot|appcloud_updates_june_2011#update3]] *June 2nd, 2011*  
 
-* [[Fix: Rubygems 1.5.2 update|appcloud_updates_june_2011#update2]] *June 2nd, 2011*  
-
-* [[<b>Major:</b> X-Forwarded-For SSL traffic enabled |appcloud_updates_june_2011#update1]] *June 2nd, 2011*  
-   
+* [[Fix: Rubygems 1.5.2 update|appcloud_updates_june_2011#update2]] *June 2nd, 2011*     
 
 ### [[May 2011|appcloud_update_2011_05_18]]
 

--- a/pages/using-rubinius-on-cloud.md
+++ b/pages/using-rubinius-on-cloud.md
@@ -4,17 +4,9 @@
 
 Rubinius is currently in Beta support on Engine Yard Cloud. This version of Rubinius brings substantial performance improvements.
 
-##Getting Started
-
-Each environment is associated with a specific version of the runtime that is used to run all applications contained in that environment.
-
 ##Support
 
 Support for users of Rubinius is provided via the dedicated [[Rubinius forum|signup-rubinius]]. All Engine Yard users can access support for Rubinius via this forum until it is promoted from the [[Engine Yard Beta Program|beta-intro]].
-
-##Known issue with Rails 3.0.10 and above
-
-Use Rails 3.0.9 or _below_ with Rubinius. Rubinius 1.2.4 is incompatible with Rails 3.0.10 and above.
 
 ##To use Rubinius for a new environment
 
@@ -25,13 +17,30 @@ Use Rails 3.0.9 or _below_ with Rubinius. Rubinius 1.2.4 is incompatible with Ra
   
 3. In the Runtime section, select Rubinius.  
 
-![Figure 1](images/rubinius_environment.png)
-
-##To edit an existing environment to use Rubinius
+##To edit an existing Passenger 3 environment to use Rubinius 
 
 1. On the Environment page, click Edit Environment.  
-2. Select Passenger 3 for the web server.  
+
+2. In the Runtime section, select Rubinius.
+
+3. Click Update Environment.
+
+4. Click !Apply.
+
+##To edit an existing non-Passenger 3 environment to use Rubinius
+
+If your environment is not already running Passenger 3, you need to stop the environment to edit it.
+
+1. Stop the environment.
+
+2. On the Environment page, click Edit Environment. 
+ 
+2. Select Passenger 3 for the Application Server Stack.  
 	Rubinius works only with Passenger 3.
 
 3. In the Runtime section, select Rubinius.  
-    If you have existing applications running in the environment, the Dashboard prompts you to rebuild the environment, which will re-run chef recipes and update the runtime to use Rubinius.
+
+4. Click Update Environment.
+
+5. Click Boot.
+  


### PR DESCRIPTION
removing June 2nd release note about Major: X-Forwarded-For SSL traffic enabled You can now request Engine Yard Support to enable HTTPS support of X-Forwarded-For via stunneled feature. And fixing the using rubinius page
