### PR TITLE
Doc 471 owners only

### DIFF
--- a/pages/linking-github-to-cloud.md
+++ b/pages/linking-github-to-cloud.md
@@ -30,13 +30,14 @@ For example, you might have two GitHub accounts: a personal GitHub account for e
 
 3. On the Create New Application page, click Link account_name.
 
-<h2 id="topic2">To link your Engine Yard account to a GitHub account (Method 2)</h2>
+<h2 id="topic5">To link your Engine Yard account to a GitHub account (Method 2)</h2>
 
 1. Log into the GitHub account that you want to link to. 
 
 2. In your Engine Yard account, go to Account > Account Settings.
 
-2. Click on the account you want to link to a GitHub account.
+2. Click on the account you want to link to a GitHub account.  
+   You must be the account **owner**.  
 
 3. Under the Services heading, click Link your account to GitHub.
 
@@ -46,7 +47,7 @@ For example, you might have two GitHub accounts: a personal GitHub account for e
 
 <h2 id="topic3">To create an application from a repository in a linked GitHub account</h2>
 
-* Create an application for Engine Yard Cloud, making sure to do the following: 
+1. Create an application for Engine Yard Cloud, making sure to do the following: 
 
     (For general instructions on creating an application, see [[Getting Started|getting_started_home]].):
 
@@ -59,9 +60,23 @@ For example, you might have two GitHub accounts: a personal GitHub account for e
 
 2. In your Engine Yard account, go to Account > Account Settings.
 
-2. Click on the account that you want to unlink from GitHub account.
+2. Click on the account that you want to unlink from GitHub account.  
+   You must be the account **owner**.  
 
 3. Under the Services heading, click un-link.
+
+<h2 id="topic6"> Troubleshooting</h2>
+
+<table>
+  <tr>
+    <th>Symptom</th><th>Solution</th>
+  </tr>
+  <tr>
+    <td>I don't see GitHub under the Services heading on the Account Settings page.</td><td>You must be the owner of the Engine Yard account to link or unlink with GitHub.<br>Ask the account owner to perform these tasks.</td>
+  </tr>
+</td>
+  </tr>
+</table>
 
 
 

--- a/pages/monitoring-new-relic.md
+++ b/pages/monitoring-new-relic.md
@@ -27,8 +27,8 @@ that the Professional plan better suits you needs.
 1. Login to your account.
 2. Click Account > Account Settings on the toolbar.
 3. Click the account name.  
-    You must be the account **owner**.
-4. Click Manage your New Relic plan under the Services section.
+    You must be the account **owner**.  
+4. Click Manage your New Relic plan under the Services section.  
       ![New Relic logo under Services](images/new_relic_logo.png)
 5. Choose the Standard plan or the Professional plan.
 6. Read and agree to the New Relic Terms of Service and select the check box. 

--- a/pages/monitoring-new-relic.md
+++ b/pages/monitoring-new-relic.md
@@ -24,17 +24,15 @@ that the Professional plan better suits you needs.
 
 ### To choose a New Relic plan
 
-  1. Login to your account.
-  2. Click Account > Account Settings on the toolbar.
-  3. Click your account name.
-
-  4. Click Manage your New Relic plan under the Services section.
-
+1. Login to your account.
+2. Click Account > Account Settings on the toolbar.
+3. Click the account name.  
+    You must be the account **owner**.
+4. Click Manage your New Relic plan under the Services section.
       ![New Relic logo under Services](images/new_relic_logo.png)
-
-  5. Choose the Standard plan or the Professional plan.
-  6. Read and agree to the New Relic Terms of Service and select the check box. 
-  7. Click Activate New Relic to activate your plan.
+5. Choose the Standard plan or the Professional plan.
+6. Read and agree to the New Relic Terms of Service and select the check box. 
+7. Click Activate New Relic to activate your plan.
 
 Your New Relic account is created automatically using your Engine Yard account and password. 
 
@@ -69,8 +67,9 @@ your application.
 ### To view New Relic data for your application
 
 1. Login to your account.
-2. Click Account > Account Settings on the toolbar.
-3. Click the account name.
+2. Click Account > Account Settings on the toolbar.  
+3. Click the account name.  
+    You must be the account **owner**.
 4. Click Access your app metrics under the Services section.
 
     ![New Relic logo under Services now activated](images/new_relic_logo_activated.png)
@@ -81,9 +80,23 @@ your application.
     **Tip:** Bookmark this New Relic page.  
 
 
-  [1]: #topic1        "topic1"
-  [2]: #topic2        "topic2"
-  [3]: #topic3        "topic3"
-  [A]: #topicA        "topicA"	
-  [B]: #topicB        "topicB"
-  [C]: #topicC        "topicC"
+<h2 id="topic6"> Troubleshooting</h2>
+
+<table>
+  <tr>
+    <th>Symptom</th><th>Solution</th>
+  </tr>
+  <tr>
+    <td>I don't see New Relic under the Services heading on the Account Settings page.</td><td>You must be the owner of the Engine Yard account to set up New Relic.<br>Ask the account owner to perform this task.</td>
+  </tr>
+</td>
+  </tr>
+</table>
+
+
+[1]: #topic1        "topic1"
+[2]: #topic2        "topic2"
+[3]: #topic3        "topic3"
+[A]: #topicA        "topicA"	
+[B]: #topicB        "topicB"
+[C]: #topicC        "topicC"


### PR DESCRIPTION
Updating the pages about New Relic and GitHub account linking to indicate that only the account owner can do these tasks.
